### PR TITLE
link.c rollback

### DIFF
--- a/brtos_unet/src/uNET/link.h
+++ b/brtos_unet/src/uNET/link.h
@@ -135,7 +135,6 @@ uint16_t   link_neighbor_table_addr16_get(uint8_t idx);
 uint8_t    link_packet_is_duplicated(uint8_t *src_addr, uint8_t seq_num);
 void       link_seqnum_reset(uint16_t src_addr);
 uint8_t    link_is_symmetric_parent(void);
-void       link_check_parent_update(void);
 uint16_t   link_get_parent_addr16(void);
 
 #endif /* UNET_LINK_H_ */

--- a/brtos_unet/src/uNET/packet.c
+++ b/brtos_unet/src/uNET/packet.c
@@ -64,8 +64,6 @@ void packet_release_down(void)
 	OSEnterCritical();
 	packet_down.state = PACKET_IDLE;
 	OSExitCritical();
-	// Check if there is new parent in the route
-	link_check_parent_update();
 }
 /*--------------------------------------------------------------------------------------------*/
 uint8_t packet_acquire_up(void)


### PR DESCRIPTION
link.c was modified to change the parent only if the packet_down was
available. But it's causing some kind of deadlock as well. So was
returned to the previous version, which seems to function well.


